### PR TITLE
Add production deployment steps and environment configuration

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,10 @@
+# Copy this file to .env.local and fill in your values.
+# Never add real credentials here — this file is committed to the repo.
+
+# Full origin of this app. Used for server-side BFF calls during SSR.
+# Must match the host the app is served from (e.g. https://yourdomain.com in prod).
+# Defaults to http://localhost:3000 if unset.
+NEXT_PUBLIC_APP_URL=https://personal-blog-yaw-dev.vercel.app
+
+# .NET backend base URL. Required — app will throw on startup if missing.
+BACKEND_URL=https://personal-blog-api-yaw-prod.fly.dev

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files — block all, but allow the example template
 .env*
 !.env.example
+!.env.production
 
 # vercel
 .vercel


### PR DESCRIPTION
This pull request adds a new `.env.production` file with placeholder environment variables for production deployment. The file provides guidance on how to set up environment variables securely and specifies the URLs needed for the frontend and backend services.

Environment variable setup:

* Added `.env.production` file with instructions to copy to `.env.local` and avoid committing real credentials.

Production configuration:

* Set `NEXT_PUBLIC_APP_URL` to the production frontend URL, used for server-side rendering and BFF calls.
* Set `BACKEND_URL` to the production backend API URL, required for the app to start.